### PR TITLE
build: configure skip deploy the usual way

### DIFF
--- a/arice/tests/pom.xml
+++ b/arice/tests/pom.xml
@@ -53,7 +53,7 @@
 
             <properties>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
-                <nexus-staging-maven-plugin.phase>none</nexus-staging-maven-plugin.phase>
+                <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
             </properties>
         </profile>
     </profiles>

--- a/modules/auto-record-tests/pom.xml
+++ b/modules/auto-record-tests/pom.xml
@@ -56,7 +56,7 @@
 
             <properties>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
-                <nexus-staging-maven-plugin.phase>none</nexus-staging-maven-plugin.phase>
+                <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
             </properties>
         </profile>
     </profiles>

--- a/modules/doc-examples/pom.xml
+++ b/modules/doc-examples/pom.xml
@@ -53,7 +53,7 @@
 
             <properties>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
-                <nexus-staging-maven-plugin.phase>none</nexus-staging-maven-plugin.phase>
+                <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                     <consoleOutputReporter>
                         <disable>true</disable>
                     </consoleOutputReporter>
-                    <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter" />
+                    <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                 </configuration>
                 <executions>
                     <execution>
@@ -197,6 +197,17 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <releaseProfiles>release</releaseProfiles>
+                    <preparationGoals>clean verify</preparationGoals>
+                    <prepareVerifyArgs>-DskipTests</prepareVerifyArgs>
+                    <scmCommentPrefix>[ci skip]</scmCommentPrefix>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
             </plugin>
         </plugins>
 
@@ -239,11 +250,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven-deploy-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <dependencies>
@@ -263,13 +269,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven-release-plugin.version}</version>
-                    <configuration>
-                        <releaseProfiles>release</releaseProfiles>
-                        <preparationGoals>clean verify</preparationGoals>
-                        <prepareVerifyArgs>-DskipTests</prepareVerifyArgs>
-                        <scmCommentPrefix>[ci skip]</scmCommentPrefix>
-                        <tagNameFormat>v@{project.version}</tagNameFormat>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -356,7 +355,7 @@
                                 <requireJavaVersion>
                                     <version>[17,)</version>
                                 </requireJavaVersion>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                     </plugin>
@@ -434,7 +433,7 @@
                             <execution>
                                 <id>attach-aggregated-javadocs</id>
                                 <goals>
-                                     <goal>aggregate-jar</goal>
+                                    <goal>aggregate-jar</goal>
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven-release-plugin.version}</version>
+                    <configuration>
+                        <releaseProfiles>release</releaseProfiles>
+                        <preparationGoals>clean verify</preparationGoals>
+                        <prepareVerifyArgs>-DskipTests</prepareVerifyArgs>
+                        <scmCommentPrefix>[ci skip]</scmCommentPrefix>
+                        <tagNameFormat>v@{project.version}</tagNameFormat>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -387,7 +394,6 @@
 
             <properties>
                 <skipTests>true</skipTests>
-                <nexus-staging-maven-plugin.phase>deploy</nexus-staging-maven-plugin.phase>
             </properties>
 
             <build>
@@ -467,23 +473,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <configuration>
-                            <preparationGoals>clean verify</preparationGoals>
-                            <prepareVerifyArgs>-Dmaven.test.skip=true</prepareVerifyArgs>
-                            <scmCommentPrefix>[ci skip]</scmCommentPrefix>
-                            <tagNameFormat>v@{project.version}</tagNameFormat>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <extensions>true</extensions>
@@ -493,15 +482,6 @@
                             <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <id>default-deploy</id>
-                                <phase>${nexus-staging-maven-plugin.phase}</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
this will permit automatic detection by maven-artifact-plugin (and every other plugin requiring to do equivalent detection)